### PR TITLE
Crash() fixes

### DIFF
--- a/scripts/agentdaemons.lua
+++ b/scripts/agentdaemons.lua
@@ -795,12 +795,11 @@ return
 		
 		onTrigger = function( self, sim, evType, evData, userUnit )
 			if evType == simdefs.TRG_UNIT_WARP and evData.unit then
-				local unit = evData.unit
-				if unit:isValid() and not unit:isPC() and unit:getTraits().mp
-				and unit:getTraits().mpMax and not unit:getTraits().transistor_debuff then
-					unit:getTraits().mp = unit:getTraits().mp - 4 --math.ceil(  )
-					unit:getTraits().mpMax = unit:getTraits().mpMax - 4
-					unit:getTraits().transistor_debuff = true
+				if evData.unit:isValid() and not evData.unit:isPC() and evData.unit:getTraits().mp
+				and evData.unit:getTraits().mpMax and not evData.unit:getTraits().transistor_debuff then
+					evData.unit:getTraits().mp = evData.unit:getTraits().mp - 4 --math.ceil(  )
+					evData.unit:getTraits().mpMax = evData.unit:getTraits().mpMax - 4
+					evData.unit:getTraits().transistor_debuff = true
 				end
 			end
 			mainframe_common.DEFAULT_ABILITY.onTrigger( self, sim, evType, evData, userUnit )

--- a/scripts/agentdaemons.lua
+++ b/scripts/agentdaemons.lua
@@ -767,24 +767,43 @@ return
 		title = STRINGS.TRANSISTOR.RED.NAME,
 		noDaemonReversal = true,
 		
-		--armor/maxMP handled in modinit.lua / init()
+		--armor handled in modinit.lua / init()
 		
 		onSpawnAbility = function( self, sim, player, agent )
+			sim:addTrigger( simdefs.TRG_UNIT_WARP, self )
 			sim:dispatchEvent( simdefs.EV_SHOW_REVERSE_DAEMON, { showMainframe=true, name=self.name, icon=self.icon, txt=self.activedesc, title=self.title } )
 			
 			sim:forEachUnit(function(unit)
-				if unit and unit:isValid() and not unit:isPC() and unit:getTraits().mp then
-					unit:getTraits().mp = unit:getTraits().mp * .5 --math.ceil(  )
+				if unit and unit:isValid() and not unit:isPC() and unit:getTraits().mp and unit:getTraits().mpMax then
+					unit:getTraits().mp = unit:getTraits().mp - 4 --math.ceil(  )
+					unit:getTraits().mpMax = unit:getTraits().mpMax - 4
+					unit:getTraits().transistor_debuff = true
 				end
 			end)
 		end,
 		
 		onDespawnAbility = function( self, sim )
+			sim:removeTrigger( simdefs.TRG_UNIT_WARP, self )
 			sim:forEachUnit(function(unit)
-				if unit and unit:isValid() and not unit:isPC() and unit:getTraits().mp then
-					unit:getTraits().mp = unit:getTraits().mp * 2
+				if unit and unit:isValid() and not unit:isPC() and unit:getTraits().mp and unit:getTraits().mpMax then
+					unit:getTraits().mp = unit:getTraits().mp + 4
+					unit:getTraits().mpMax = unit:getTraits().mpMax + 4
+					unit:getTraits().transistor_debuff = nil
 				end
 			end)
+		end,
+		
+		onTrigger = function( self, sim, evType, evData, userUnit )
+			if evType == simdefs.TRG_UNIT_WARP and evData.unit then
+				local unit = evData.unit
+				if unit:isValid() and not unit:isPC() and unit:getTraits().mp
+				and unit:getTraits().mpMax and not unit:getTraits().transistor_debuff then
+					unit:getTraits().mp = unit:getTraits().mp - 4 --math.ceil(  )
+					unit:getTraits().mpMax = unit:getTraits().mpMax - 4
+					unit:getTraits().transistor_debuff = true
+				end
+			end
+			mainframe_common.DEFAULT_ABILITY.onTrigger( self, sim, evType, evData, userUnit )
 		end,
 	},
 	


### PR DESCRIPTION
Moved mpMax change here, instead of halved AP units lose 4 AP instead, added warp trigger to apply the debuff to units spawned in after Crash() proccs